### PR TITLE
Fixed the custom datetime parsing

### DIFF
--- a/jquery.countdown.js
+++ b/jquery.countdown.js
@@ -271,13 +271,12 @@
                     ms_offset = (offset[1] === '+') ? -ms_offset : ms_offset;
                 }
                 var now = new Date();
-                hh = time_array[4] ? this.hToMs(time_array[4]) : 0;
-                mm = time_array[5] ? this.mToMs(time_array[5]) : 0;
-                ss = time_array[6] ? this.sToMs(time_array[6]) : 0;
-                now.setTime(hh + mm + ss);
-                now.setDate(time_array[3]);
-                now.setMonth(time_array[2] - 1);
-                now.setFullYear(time_array[1]);
+                now.setUTCHours(time_array[4]);
+                now.setUTCMinutes(time_array[5]);
+                now.setUTCSeconds(time_array[6]);
+                now.setUTCDate(time_array[3]);
+                now.setUTCMonth(time_array[2] - 1);
+                now.setUTCFullYear(time_array[1]);
                 now.setTime(now.getTime() + ms_offset);  // Add or substract timezone offset => UTC time.
                 return now;
             }


### PR DESCRIPTION
The timezone offset was not correctly applied, because the UTC offset was applied to a local time. Now an UTC date is created and the UTC offset is applied to this date, which seems like the correct behaviour to me.

This method is only used in browsers that don't support the ISO8601 timeformat natively (i.e. Internet Explorer < 9).
